### PR TITLE
Add Fish Shell Configuration for GitHub Copilot

### DIFF
--- a/conf.d/gh-copilot.fish
+++ b/conf.d/gh-copilot.fish
@@ -1,0 +1,16 @@
+# Check if the gh CLI is installed
+if not command -v gh >/dev/null
+    echo "GitHub CLI (gh) is not installed. Installing it now..."
+    if command -v brew >/dev/null
+        brew install gh
+    end
+end
+
+# Check if the GitHub Copilot CLI extension is installed
+if not gh extension list | grep -q github/gh-copilot
+    echo "GitHub CLI Copilot (gh extension github/gh-copilot) is not installed. Installing it now..."
+    gh extension install github/gh-copilot --force
+end
+
+# Set up gh copilot alias for Fish shell
+# gh copilot alias -- fish | source

--- a/fish-functions/ghce.fish
+++ b/fish-functions/ghce.fish
@@ -1,0 +1,44 @@
+function ghce
+    set -l GH_DEBUG "$GH_DEBUG"
+    set -l GH_HOST "$GH_HOST"
+
+    set -l __USAGE "
+Wrapper around \`gh copilot explain\` to explain a given input command in natural language.
+
+USAGE
+    $argv[1] [flags] <command>
+
+FLAGS
+    -d, --debug      Enable debugging
+    -h, --help       Display help usage
+        --hostname   The GitHub host to use for authentication
+
+EXAMPLES
+
+# View disk usage, sorted by size
+$argv[1] 'du -sh | sort -h'
+
+# View git repository history as text graphical representation
+$argv[1] 'git log --oneline --graph --decorate --all'
+
+# Remove binary objects larger than 50 megabytes from git history
+$argv[1] 'bfg --strip-blobs-bigger-than 50M'
+    "
+
+    set -l OPT OPTARG OPTIND
+    for arg in $argv
+        switch $arg
+            case --debug -d
+                set GH_DEBUG api
+                continue
+            case --help -h
+                echo "$__USAGE"
+                return 0
+            case --hostname
+                set GH_HOST (next $argv)
+                continue
+        end
+    end
+
+    GH_DEBUG="$GH_DEBUG" GH_HOST="$GH_HOST" gh copilot explain $argv
+end

--- a/fish-functions/ghcs.fish
+++ b/fish-functions/ghcs.fish
@@ -1,0 +1,79 @@
+# gh copilot alias
+# https://github.com/github/gh-copilot?tab=readme-ov-file
+
+function ghcs
+    set TARGET shell
+    set -l GH_DEBUG "$GH_DEBUG"
+    set -l GH_HOST "$GH_HOST"
+
+    set -l __USAGE "
+Wrapper around \`gh copilot suggest\` to suggest a command based on a natural language description of the desired output effort.
+Supports executing suggested commands if applicable.
+
+USAGE
+    $argv[1] [flags] <prompt>
+
+FLAGS
+    -d, --debug              Enable debugging
+    -h, --help               Display help usage
+        --hostname           The GitHub host to use for authentication
+    -t, --target target      Target for suggestion; must be shell, gh, git
+                             default: \"$TARGET\"
+
+EXAMPLES
+
+- Guided experience
+    $argv[1]
+
+- Git use cases
+    $argv[1] -t git \"Undo the most recent local commits\"
+    $argv[1] -t git \"Clean up local branches\"
+    $argv[1] -t git \"Setup LFS for images\"
+
+- Working with the GitHub CLI in the terminal
+    $argv[1] -t gh \"Create pull request\"
+    $argv[1] -t gh \"List pull requests waiting for my review\"
+    $argv[1] -t gh \"Summarize work I have done in issues and pull requests for promotion\"
+
+- General use cases
+    $argv[1] \"Kill processes holding onto deleted files\"
+    $argv[1] \"Test whether there are SSL/TLS issues with github.com\"
+    $argv[1] \"Convert SVG to PNG and resize\"
+    $argv[1] \"Convert MOV to animated PNG\"
+    "
+
+    set -l OPT OPTARG OPTIND
+    for arg in $argv
+        switch $arg
+            case --debug -d
+                set GH_DEBUG api
+                continue
+            case --help -h
+                echo "$__USAGE"
+                return 0
+            case --hostname
+                set GH_HOST (next $argv)
+                continue
+            case --target -t
+                set TARGET (next $argv)
+                continue
+        end
+    end
+
+    set -l TMPFILE (mktemp -t gh-copilotXXXXXX)
+    function cleanup --on-event fish_exit
+        rm -f "$TMPFILE"
+    end
+
+    if GH_DEBUG="$GH_DEBUG" GH_HOST="$GH_HOST" gh copilot suggest -t "$TARGET" $argv --shell-out "$TMPFILE"
+        if test -s "$TMPFILE"
+            set -l FIXED_CMD (cat $TMPFILE)
+            builtin history -s -- (builtin history 1 | cut -d' ' -f4-)
+            builtin history -s -- "$FIXED_CMD"
+            echo
+            eval -- "$FIXED_CMD"
+        else
+            return 1
+        end
+    end
+end


### PR DESCRIPTION
 **The configuration file sets up aliases and environment variables necessary for integrating GitHub Copilot with the Fish shell.**

```fish
# ~/.config/fish/conf.d/gh-copilot.fish

# Check if the gh CLI is installed
if not command -v gh >/dev/null
    echo "GitHub CLI (gh) is not installed. Installing it now..."
    if command -v brew >/dev/null
        brew install gh
    end
end

# Check if the GitHub Copilot CLI extension is installed
if not gh extension list | grep -q github/gh-copilot
    echo "GitHub CLI Copilot (gh extension github/gh-copilot) is not installed. Installing it now..."
    gh extension install github/gh-copilot --force
end

# Set up gh copilot alias for Fish shell
# gh copilot alias -- fish | source
```

```fish
# ~/.config/fish/functions/.ghcs.fish

function ghcs
    set TARGET shell
    set -l GH_DEBUG "$GH_DEBUG"
    set -l GH_HOST "$GH_HOST"

    set -l __USAGE "
Wrapper around \`gh copilot suggest\` to suggest a command based on a natural language description of the desired output effort.
Supports executing suggested commands if applicable.

USAGE
    $argv[1] [flags] <prompt>

FLAGS
    -d, --debug              Enable debugging
    -h, --help               Display help usage
        --hostname           The GitHub host to use for authentication
    -t, --target target      Target for suggestion; must be shell, gh, git
                             default: \"$TARGET\"

EXAMPLES

- Guided experience
    $argv[1]

- Git use cases
    $argv[1] -t git \"Undo the most recent local commits\"
    $argv[1] -t git \"Clean up local branches\"
    $argv[1] -t git \"Setup LFS for images\"

- Working with the GitHub CLI in the terminal
    $argv[1] -t gh \"Create pull request\"
    $argv[1] -t gh \"List pull requests waiting for my review\"
    $argv[1] -t gh \"Summarize work I have done in issues and pull requests for promotion\"

- General use cases
    $argv[1] \"Kill processes holding onto deleted files\"
    $argv[1] \"Test whether there are SSL/TLS issues with github.com\"
    $argv[1] \"Convert SVG to PNG and resize\"
    $argv[1] \"Convert MOV to animated PNG\"
    "

    set -l OPT OPTARG OPTIND
    for arg in $argv
        switch $arg
            case --debug -d
                set GH_DEBUG api
                continue
            case --help -h
                echo "$__USAGE"
                return 0
            case --hostname
                set GH_HOST (next $argv)
                continue
            case --target -t
                set TARGET (next $argv)
                continue
        end
    end

    set -l TMPFILE (mktemp -t gh-copilotXXXXXX)
    function cleanup --on-event fish_exit
        rm -f "$TMPFILE"
    end

    if GH_DEBUG="$GH_DEBUG" GH_HOST="$GH_HOST" gh copilot suggest -t "$TARGET" $argv --shell-out "$TMPFILE"
        if test -s "$TMPFILE"
            set -l FIXED_CMD (cat $TMPFILE)
            builtin history -s -- (builtin history 1 | cut -d' ' -f4-)
            builtin history -s -- "$FIXED_CMD"
            echo
            eval -- "$FIXED_CMD"
        else
            return 1
        end
    end
end
```

```fish
# ~/.config/fish/functions/.ghce.fish

function ghce
    set -l GH_DEBUG "$GH_DEBUG"
    set -l GH_HOST "$GH_HOST"

    set -l __USAGE "
Wrapper around \`gh copilot explain\` to explain a given input command in natural language.

USAGE
    $argv[1] [flags] <command>

FLAGS
    -d, --debug      Enable debugging
    -h, --help       Display help usage
        --hostname   The GitHub host to use for authentication

EXAMPLES

# View disk usage, sorted by size
$argv[1] 'du -sh | sort -h'

# View git repository history as text graphical representation
$argv[1] 'git log --oneline --graph --decorate --all'

# Remove binary objects larger than 50 megabytes from git history
$argv[1] 'bfg --strip-blobs-bigger-than 50M'
    "

    set -l OPT OPTARG OPTIND
    for arg in $argv
        switch $arg
            case --debug -d
                set GH_DEBUG api
                continue
            case --help -h
                echo "$__USAGE"
                return 0
            case --hostname
                set GH_HOST (next $argv)
                continue
        end
    end

    GH_DEBUG="$GH_DEBUG" GH_HOST="$GH_HOST" gh copilot explain $argv
end
```